### PR TITLE
fix: handle race conditions in checkLastTransaction and confirmAcquirer

### DIFF
--- a/api/sql/schema/750$transfer.push.checkLastTransaction.sql
+++ b/api/sql/schema/750$transfer.push.checkLastTransaction.sql
@@ -34,59 +34,71 @@ BEGIN TRY
         @lastNotes4 = e.udfDetails.value('(/root/type4Notes)[1]', 'int')
     FROM
         [transfer].[transfer] t
-    JOIN
+    LEFT JOIN
         [transfer].[event] e ON e.transferId = t.transferId AND e.source = 'acquirer' AND e.type = 'transfer.requestAcquirer'
     WHERE
         t.channelId = @channelId
     ORDER BY
         t.transferId DESC
 
+    IF @lastAcquirerState IS NULL AND @lastTx IS NOT NULL
+    BEGIN
+        EXEC [transfer].[push.abortAcquirer]
+            @transferId = @lastTx,
+            @type = 'atm.lastTransactionTimeout',
+            @message = 'ATM timed out waiting for response',
+            @details = @callParams
+    END ELSE
     IF @lastAcquirerState=1 AND @lastIssuerState=2
     BEGIN
-        if @lastSernum != @sernum
+        IF @lastSernum IS NULL
+        BEGIN
+            EXEC [transfer].[push.errorAcquirer]
+                @transferId = @lastTx,
+                @type = 'atm.lastTransactionMissingSernum',
+                @message = 'Missing last transaction serial number',
+                @details = @callParams
+        END ELSE
+        IF @lastSernum != @sernum
         BEGIN
             IF @confirm = 1
             BEGIN
-                EXEC [transfer].[push.event]
+                EXEC [transfer].[push.errorAcquirer]
                     @transferId = @lastTx,
-                    @type = 'atm.lastTransactionNoReply',
-                    @state = 'fail',
-                    @source = 'acquirer',
+                    @type = 'atm.lastTransactionUnexpectedSernum',
                     @message = 'Unexpected last transaction serial number',
-                    @udfDetails = NULL
+                    @details = @callParams
             END ELSE
             BEGIN
                 EXEC [transfer].[push.failAcquirer]
                     @transferId = @lastTx,
                     @type = 'atm.lastTransactionNoReply',
                     @message = 'ATM did not receive transaction reply',
-                    @details = NULL
+                    @details = @callParams
             END
         END else
         IF @lastNotes1 != @notes1 OR @lastNotes2 != @notes2 OR @lastNotes3 != @notes3 OR @lastNotes4 != @notes4
         BEGIN
             IF @confirm = 1
             BEGIN
-                EXEC [transfer].[push.event]
+                EXEC [transfer].[push.errorAcquirer]
                     @transferId = @lastTx,
-                    @type = 'atm.lastTransactionNoReply',
-                    @state = 'fail',
-                    @source = 'acquirer',
+                    @type = 'atm.lastTransactionUnexpectedDispense',
                     @message = 'Unexpected last dispense',
-                    @udfDetails = NULL
+                    @details = @callParams
             END ELSE
             IF @notes1 = 0 AND @notes2 = 0 AND @notes3 = 0 AND @notes4 = 0
                 EXEC [transfer].[push.failAcquirer]
                     @transferId = @lastTx,
-                    @type = 'atm.lastTransactionZero',
+                    @type = 'atm.lastTransactionZeroDispense',
                     @message = 'ATM did not dispense any money',
-                    @details = NULL
+                    @details = @callParams
             else
                 EXEC [transfer].[push.errorAcquirer]
                     @transferId = @lastTx,
-                    @type = 'atm.lastTransactionDifferent',
+                    @type = 'atm.lastTransactionDifferentDispense',
                     @message = 'ATM dispensed different amount',
-                    @details = NULL
+                    @details = @callParams
         END else
         BEGIN
             EXEC [transfer].[push.confirmAcquirer]
@@ -94,7 +106,7 @@ BEGIN TRY
                 @transferIdAcquirer = NULL,
                 @type = NULL,
                 @message = NULL,
-                @details = NULL
+                @details = @callParams
         END
     end
 

--- a/api/sql/schema/750$transfer.push.confirmAcquirer.sql
+++ b/api/sql/schema/750$transfer.push.confirmAcquirer.sql
@@ -14,7 +14,7 @@ SET
     acquirerTxState = 2
 WHERE
     transferId = @transferId AND
-    acquirerTxState = 1
+    acquirerTxState in (1, 2)
 
 DECLARE @COUNT int = @@ROWCOUNT
 


### PR DESCRIPTION
Note that now calling confirmAcquirer on already confirmed (by acquirer) transfer will not throw error.