### PR TITLE
fix: insert card reversals into transfer table

### DIFF
--- a/api/sql/schema/650$transfer.vReversal.sql
+++ b/api/sql/schema/650$transfer.vReversal.sql
@@ -5,7 +5,8 @@ FROM
     [transfer].[transfer] t
 JOIN
     [transfer].[partner] p ON (((
-        (t.issuerTxState = 2 AND ISNULL(t.acquirerTxState, 0) IN (0, 3, 4, 5) AND p.mode = 'online' AND t.channelType IN ('ATM')) OR --tx succeeded at issuer during online but failed at acquirer and current mode is online
+        (t.issuerTxState = 2 AND ISNULL(t.acquirerTxState, 0) IN (0, 3, 4, 5) AND p.mode = 'online' AND t.channelType IN ('ATM')) OR --tx succeeded at issuer during online but failed at acquirer (ATM) and current mode is online
+        (t.issuerTxState = 2 AND ISNULL(t.acquirerTxState, 0) IN (4) AND p.mode = 'online' AND t.channelType IN ('ISO')) OR --tx succeeded at issuer during online but reversed by acquirer (ISO) and current mode is online
         (t.issuerTxState = 8 AND ISNULL(t.acquirerTxState, 0) IN (0, 3, 4, 5) AND p.mode IN ('online', 'offline')) OR --tx succeeded at issuer during offline but failed at acquirer and current mode is online/offline
         (ISNULL(t.merchantTxState, 0) IN (1, 3)) OR --tx failed at merchant (succeeded at issuer implicitly)
         (t.issuerTxState IN (1, 4) AND p.mode = 'online') OR --tx timed out at issuer during online and current mode is online

--- a/api/sql/schema/750$transfer.push.reverseAcquirer.sql
+++ b/api/sql/schema/750$transfer.push.reverseAcquirer.sql
@@ -12,7 +12,7 @@ SET
     acquirerTxState = 4
 WHERE
     transferId = @transferId AND
-    acquirerTxState = 1
+    ISNULL(acquirerTxState, 1) = 1
 
 DECLARE @COUNT INT = @@ROWCOUNT
 EXEC [transfer].[push.event]

--- a/api/sql/schema/750$transfer.transfer.get.sql
+++ b/api/sql/schema/750$transfer.transfer.get.sql
@@ -8,6 +8,7 @@ ALTER PROCEDURE [transfer].[transfer.get]
     @transferIdIssuer VARCHAR(50) = NULL,
     @issuerId VARCHAR(50) = NULL,
     @pan VARCHAR(32) = NULL,
+    @amount MONEY = NULL,
     @meta core.metaDataTT READONLY -- information for the user that makes the operation
 
 AS
@@ -121,6 +122,7 @@ WHERE
     (@acquirerCode IS NULL OR t.acquirerCode = @acquirerCode) AND
     (@retrievalReferenceNumber IS NULL OR t.retrievalReferenceNumber = @retrievalReferenceNumber) AND
     (@pan IS NULL OR e.[udfDetails].value('(/root/pan)[1]', 'VARCHAR(32)') = @pan) AND
+    (@amount IS NULL OR t.transferAmount = @amount) AND
     pullTransactionId IS NOT NULL
 ORDER BY
     t.transferDateTime DESC
@@ -209,7 +211,8 @@ BEGIN
         (@localDateTime IS NULL OR t.localDateTime LIKE '%' + @localDateTime) AND
         (@acquirerCode IS NULL OR t.acquirerCode = @acquirerCode) AND
         (@retrievalReferenceNumber IS NULL OR t.retrievalReferenceNumber = @retrievalReferenceNumber) AND
-        (@pan IS NULL OR e.[udfDetails].value('(/root/pan)[1]', 'VARCHAR(32)') = @pan)
+        (@pan IS NULL OR e.[udfDetails].value('(/root/pan)[1]', 'VARCHAR(32)') = @pan) AND
+        (@amount IS NULL OR t.transferAmount = @amount)
     ORDER BY
         t.transferDateTime DESC
 END

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   },
   "devDependencies": {
     "tap": "^12.6.1",
-    "ut-tools": "^6.15.0",
     "ut-run": "^10.3.1",
-    "ut-test": "^5.19.6"
+    "ut-test": "^5.19.6",
+    "ut-tools": "^6.21.0"
   },
   "peerDependencies": {
     "immutable": "^3.8.1",


### PR DESCRIPTION
**Implemented is new method "transfer.card.reverse".**
This new method reverses transfer if exist or inserts it into the database as failed transfer.
Additionally, the reversal message accepts parameter "transferQuery".
UT transfer will use the data from this object to find the source transfer, this is to allow implementation specific search and more flexibility.
If "transferQuery" object is omitted, the default query will be created using standard fields from the reversal message.
This parameter applies for both "transfer.card.reverse" and "transfer.push.reverse".
**Additionally, implementations can apply constraints in the database to prevent duplicated transactions or "reversal-before-transaction" cases.**

**Implemented are async reversals.**
UT transfer will check if the reversal message has flag "reverseAsync".
If UT the flag is set to true, the reversals will be processed in asynchronous fashion.
Asynchronous reversals have completely different behaviour.
Asynchronous reversals are useful for POS and ISO channels.
Here is the flow:
1. Acquirer sends reversal message with flag "reverseAsync"
2. UT transfer queries the source transfer
3. If the source transfer is not found, the reversal will be rejected
4. If the source transfer is found and not eligible for reversal, the request will be rejected
5. If the source transfer is found and eligible for reversal, the request will be approved.

Asynchronous reversals differ from synchronous reversals in step 5.
With asynchronous reversals, UT-transfer approves the reversal request immediately and does not reverse the transfer in CBS.
Instead, it sets the acquirerTxState to value 4 using 'transfer.push.reverseAcquirer'.
The reversal in the CBS happen later on using 'transfer.idle.execute'.
