### PR TITLE
fix: do not erase transferIdAcquirer

### DIFF
--- a/api/sql/schema/750$transfer.push.confirmAcquirer.sql
+++ b/api/sql/schema/750$transfer.push.confirmAcquirer.sql
@@ -10,7 +10,7 @@ SET NOCOUNT ON
 UPDATE
     [transfer].[transfer]
 SET
-    [transferIdAcquirer] = @transferIdAcquirer,
+    [transferIdAcquirer] = ISNULL(@transferIdAcquirer, transferIdAcquirer),
     acquirerTxState = 2
 WHERE
     transferId = @transferId AND


### PR DESCRIPTION
Having transferIdAcquirer **erased** with transfer.push.confirmAcquirer
feels like side effect and unwanted behavior.

If i don't know this ID but i want to confirm the acquirer operation,
**i would pass "null" value to it** and expect it to be ignored.
If i need to erase this value, it is completely  different (abnormal) scenario
and **should be done with different procedure**.
For example please see transfer.push.checkLastTransaction procedure.

This procedure is not intended to erase transferIdAcquirer value, **but replace it or set it**.