### PR TITLE
fix: generate acquirerId in any case

### DIFF
--- a/api/script/index.js
+++ b/api/script/index.js
@@ -637,7 +637,7 @@ module.exports = function transferFlow({utError: {fetchErrors}}) {
                 cardDetails,
                 processAcquirerError
             ]) => {
-                const transfer = Object.assign({}, acquirerId, cardDetails, params);
+                const transfer = Object.assign({}, acquirerId, params, cardDetails);
                 const selectFirstError = errors => errors.find(e => e);
                 transfer.abortAcquirer = selectFirstError([
                     processAcquirerError.abortAcquirer,


### PR DESCRIPTION
Reports and common recon/debug practices require transferIdAcquirer to be present.

The changes are also trying to achieve better concurrency and better code readability.